### PR TITLE
gpu-l2-cache SYCL version

### DIFF
--- a/gpu-l2-cache/sycl/build.sh
+++ b/gpu-l2-cache/sycl/build.sh
@@ -1,0 +1,2 @@
+clang++ -O3 -fsycl -fsycl-targets=nvptx64-nvidia-cuda sycl-gpu-l2-cache.cpp -o  sycl-gpu-l2-cache -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_80
+./sycl-gpu-l2-cache

--- a/gpu-l2-cache/sycl/sycl-gpu-l2-cache.cpp
+++ b/gpu-l2-cache/sycl/sycl-gpu-l2-cache.cpp
@@ -1,0 +1,74 @@
+#include <sycl/sycl.hpp>
+#include <iostream>
+#include <chrono>
+#include <stdlib.h>
+#include <numeric>
+#include <iomanip>
+#include <algorithm>
+#include <vector>
+
+using namespace sycl;
+using dtype = double;
+
+int main(int argc, char **argv) {
+  const int N = 64;
+  std::cout << std::setw(13) << "data set"   //
+       << std::setw(12) << "exec time"  //
+       << std::setw(11) << "spread"     //
+       << std::setw(15) << "Eff. bw\n"; //
+
+  sycl::queue q{sycl::gpu_selector_v,sycl::property::queue::enable_profiling{}};
+  std::cout << "Running on GPU:" << q.get_device().get_info<sycl::info::device::name>()<< std::endl;
+     
+
+  for (int blockRun = 3; blockRun < 10000; blockRun += max(1.0, blockRun * 0.1)) {
+    const int blockSize = 1024;
+    const int blockCount = 200000;
+
+    std::vector<double> time;
+
+    for (int i = 0; i < 11; i++) {
+      const size_t bufferCount = blockRun * blockSize * N + i * 128;
+      dtype *dA = malloc_device<dtype>(bufferCount, q);
+      dtype *dB = malloc_device<dtype>(bufferCount, q);
+
+      q.parallel_for(range<1>(bufferCount), [=](id<1> idx) {
+        dA[idx] = dtype(1.1);
+        dB[idx] = dtype(1.1);
+      }).wait();
+
+      auto start = std::chrono::high_resolution_clock::now();
+      q.parallel_for(nd_range<1>(range<1>(blockCount * blockSize), range<1>(blockSize)), [=](nd_item<1> item) {
+        int threadIdx = item.get_local_id(0);
+        int blockIdx = item.get_group(0);
+
+        dtype localSum = dtype(0);
+        for (int i = 0; i < N / 2; i++) {
+          int idx = (blockSize * blockRun * i + (blockIdx % blockRun) * blockSize) * 2 + threadIdx;
+          localSum += dB[idx] * dB[idx + blockSize];
+        }
+        localSum *= (dtype)1.3;
+        if (threadIdx > 1233 || localSum == (dtype)23.12)
+          dA[threadIdx] += localSum;
+      }).wait();
+      auto end = std::chrono::high_resolution_clock::now();
+      auto elapsedtime = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+      time.push_back(std::chrono::duration<double>(elapsedtime).count());
+
+      free(dA, q);
+      free(dB, q);
+    }
+
+    std::sort(time.begin(), time.end());
+    double blockDV = N * blockSize * sizeof(dtype);
+    double bw = blockDV * blockCount / time[0] / 1.0e9; // time min value
+
+    std::cout << std::fixed << std::setprecision(0) << std::setw(10) << blockDV / 1024 << " kB"
+              << std::fixed << std::setprecision(0) << std::setw(10) << blockDV * blockRun / 1024 << " kB"
+              << std::fixed << std::setprecision(0) << std::setw(10) << (time[0] * 1000.0) << "ms"
+              << std::setprecision(1) << std::setw(10)
+              << abs(*(begin(time)) - *(end(time) - 1)) /
+                     std::accumulate(begin(time) + 1, end(time) - 1, 0.0) / (time.size() - 2) * 100
+              << "%" << std::setw(10) << bw << " GB/s   " << std::endl;
+  }
+}


### PR DESCRIPTION
Hi, 
After understanding the underlying concepts, I had an idea of having this project with vendor agnostic language `sycl` since it is well supported by the Intel, Nvidia and AMD GPUs. It would be great addition since the Intel based GPU benchmarking is also going to be available with this. 

Initially tested with NVIDIA A100 and results are performing similar to the CUDA version : 

```
     data set   exec time     spread       Eff. bw
Running on GPU:
:	NVIDIA A100-SXM4-40GB
       512 kB      1536 kB        19ms       0.2%    5518.8 GB/s   
       512 kB      2048 kB        19ms       0.0%    5518.8 GB/s   
       512 kB      2560 kB        19ms       0.0%    5518.8 GB/s   
       512 kB      3072 kB        19ms       0.0%    5518.8 GB/s   
       512 kB      3584 kB        19ms       0.0%    5518.8 GB/s   
       512 kB      4096 kB        19ms       0.0%    5518.8 GB/s   
       512 kB      4608 kB        19ms       0.0%    5518.8 GB/s   
       512 kB      5120 kB        19ms       0.0%    5518.8 GB/s   
       512 kB      5632 kB        19ms       0.0%    5518.8 GB/s   
       512 kB      6144 kB        19ms       0.0%    5518.8 GB/s   
       512 kB      6656 kB        19ms       0.0%    5518.8 GB/s   
       512 kB      7168 kB        19ms       0.0%    5518.8 GB/s   
       512 kB      7680 kB        19ms       0.0%    5518.8 GB/s   
       512 kB      8192 kB        19ms       0.0%    5518.8 GB/s   
       512 kB      8704 kB        19ms       0.0%    5518.8 GB/s   
       512 kB      9216 kB        19ms       0.0%    5518.8 GB/s   
       512 kB      9728 kB        19ms       0.0%    5518.8 GB/s   
       512 kB     10240 kB        19ms       0.1%    5518.8 GB/s   
       512 kB     11264 kB        19ms       0.0%    5518.8 GB/s   
       512 kB     12288 kB        19ms       0.0%    5518.8 GB/s   
       512 kB     13312 kB        19ms       0.0%    5518.8 GB/s   
       512 kB     14336 kB        19ms       0.0%    5518.8 GB/s   
       512 kB     15360 kB        19ms       0.0%    5518.8 GB/s   
       512 kB     16896 kB        19ms       0.0%    5518.8 GB/s   
       512 kB     18432 kB        19ms       0.0%    5518.8 GB/s   
       512 kB     19968 kB        19ms       0.0%    5518.8 GB/s   
       512 kB     21504 kB        19ms       0.0%    5518.8 GB/s   
       512 kB     23552 kB        19ms       0.0%    5518.8 GB/s   
       512 kB     25600 kB        19ms       0.0%    5518.8 GB/s   
       512 kB     28160 kB        20ms       0.1%    5242.9 GB/s   
       512 kB     30720 kB        26ms       0.0%    4033.0 GB/s   
       512 kB     33792 kB        32ms       0.0%    3276.8 GB/s   
       512 kB     36864 kB        42ms       0.0%    2496.6 GB/s   
       512 kB     40448 kB        54ms       0.0%    1941.8 GB/s   
       512 kB     44032 kB        61ms       0.0%    1719.0 GB/s   
       512 kB     48128 kB        66ms       0.0%    1588.8 GB/s   
       512 kB     52736 kB        68ms       0.0%    1542.0 GB/s   
       512 kB     57856 kB        69ms       0.0%    1519.7 GB/s   
       512 kB     63488 kB        69ms       0.0%    1519.7 GB/s   
       512 kB     69632 kB        69ms       0.0%    1519.7 GB/s   
       512 kB     76288 kB        69ms       0.0%    1519.7 GB/s   
       512 kB     83456 kB        69ms       0.0%    1519.7 GB/s   
       512 kB     91648 kB        69ms       0.0%    1519.7 GB/s   
       512 kB    100352 kB        69ms       0.0%    1519.7 GB/s   
       512 kB    110080 kB        69ms       0.0%    1519.7 GB/s   
       512 kB    120832 kB        69ms       0.0%    1519.7 GB/s   
       512 kB    132608 kB        69ms       0.0%    1519.7 GB/s   
       512 kB    145408 kB        70ms       0.0%    1498.0 GB/s   
       512 kB    159744 kB        70ms       0.0%    1498.0 GB/s   
       512 kB    175616 kB        70ms       0.0%    1498.0 GB/s   
       512 kB    193024 kB        70ms       0.0%    1498.0 GB/s   
       512 kB    211968 kB        70ms       0.0%    1498.0 GB/s   
       512 kB    232960 kB        70ms       0.0%    1498.0 GB/s   
       512 kB    256000 kB        70ms       0.0%    1498.0 GB/s   
       512 kB    281600 kB        70ms       0.0%    1498.0 GB/s   
       512 kB    309760 kB        70ms       0.0%    1498.0 GB/s   
       512 kB    340480 kB        70ms       0.0%    1498.0 GB/s   
       512 kB    374272 kB        70ms       0.0%    1498.0 GB/s   
       512 kB    411648 kB        71ms       0.0%    1476.9 GB/s   
       512 kB    452608 kB        71ms       0.0%    1476.9 GB/s   
       512 kB    497664 kB        71ms       0.0%    1476.9 GB/s   
       512 kB    547328 kB        71ms       0.0%    1476.9 GB/s   
       512 kB    601600 kB        71ms       0.0%    1476.9 GB/s   
       512 kB    661504 kB        71ms       0.0%    1476.9 GB/s   
       512 kB    727552 kB        72ms       0.0%    1456.4 GB/s   
       512 kB    800256 kB        72ms       0.0%    1456.4 GB/s   
       512 kB    880128 kB        72ms       0.0%    1456.4 GB/s   
       512 kB    967680 kB        73ms       0.0%    1436.4 GB/s   
       512 kB   1064448 kB        73ms       0.0%    1436.4 GB/s   
       512 kB   1170432 kB        73ms       0.0%    1436.4 GB/s   
       512 kB   1287168 kB        74ms       0.0%    1417.0 GB/s   
       512 kB   1415680 kB        74ms       0.0%    1417.0 GB/s   
       512 kB   1556992 kB        75ms       0.0%    1398.1 GB/s   
       512 kB   1712640 kB        75ms       0.0%    1398.1 GB/s   
       512 kB   1883648 kB        75ms       0.0%    1398.1 GB/s   
       512 kB   2071552 kB        75ms       0.0%    1398.1 GB/s   
       512 kB   2278400 kB        75ms       0.0%    1398.1 GB/s   
       512 kB   2506240 kB        75ms       0.0%    1398.1 GB/s   
       512 kB   2756608 kB        75ms       0.0%    1398.1 GB/s   
       512 kB   3032064 kB        75ms       0.0%    1398.1 GB/s   
       512 kB   3335168 kB        75ms       0.0%    1398.1 GB/s   
       512 kB   3668480 kB        75ms       0.0%    1398.1 GB/s   
       512 kB   4035072 kB        75ms       0.0%    1398.1 GB/s   
       512 kB   4438528 kB        75ms       0.0%    1398.1 GB/s   
       512 kB   4881920 kB        75ms       0.0%    1398.1 GB/s   
```

